### PR TITLE
fix(frontend): replace deprecated Jira endpoint

### DIFF
--- a/src/frontend/src/hooks/__snapshots__/useJiraSearch.test.ts.snap
+++ b/src/frontend/src/hooks/__snapshots__/useJiraSearch.test.ts.snap
@@ -2,9 +2,9 @@
 
 exports[`requests jira when function value is "COUNT" 1`] = `
 [
-  "/rest/api/3/search",
+  "/rest/api/3/search/jql",
   {
-    "body": "{"jql":"test","maxResults":0}",
+    "body": "{"jql":"test","maxResults":5000}",
     "headers": {
       "Accept": "application/json",
       "Content-Type": "application/json",
@@ -16,7 +16,7 @@ exports[`requests jira when function value is "COUNT" 1`] = `
 
 exports[`requests jira when function value is "SUM" 1`] = `
 [
-  "/rest/api/3/search",
+  "/rest/api/3/search/jql",
   {
     "body": "{"jql":"test"}",
     "headers": {

--- a/src/frontend/src/hooks/useJiraSearch.ts
+++ b/src/frontend/src/hooks/useJiraSearch.ts
@@ -2,7 +2,9 @@ import { requestJira } from '@forge/bridge';
 import { useEffect, useState } from 'react';
 
 import { log } from '../helpers';
-import { FormValues, Issue } from '../types';
+import type { FormValues, Issue } from '../types';
+
+const MAX_RESULTS = 5000;
 
 export function useJiraSearch(formValues: FormValues) {
   const [isLoading, setIsLoading] = useState(true);
@@ -14,7 +16,7 @@ export function useJiraSearch(formValues: FormValues) {
     }
 
     const requests = formValues.jql.map((jql, index) =>
-      requestJira('/rest/api/3/search', {
+      requestJira('/rest/api/3/search/jql', {
         method: 'POST',
         headers: {
           Accept: 'application/json',
@@ -23,10 +25,13 @@ export function useJiraSearch(formValues: FormValues) {
         body: JSON.stringify({
           jql,
           maxResults:
-            formValues.function[index].value === 'COUNT' ? 0 : undefined,
+            formValues.function[index].value === 'COUNT'
+              ? MAX_RESULTS
+              : undefined,
         }),
       })
         .then((response) => response.json())
+        // TODO: fetch `nextPageToken` if there are more issues
         .catch(log.error),
     );
 

--- a/src/frontend/src/types/response.ts
+++ b/src/frontend/src/types/response.ts
@@ -1,6 +1,10 @@
+/**
+ * {@link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-search/#api-rest-api-3-search-jql-post-response}
+ */
 export interface Issue {
-  startAt: number;
-  maxResults: number;
-  total: number;
-  issues: object[];
+  isLast: boolean;
+  issues: { id: string }[];
+  names?: object;
+  nextPageToken?: string;
+  schema?: object;
 }

--- a/src/frontend/src/view/helpers.ts
+++ b/src/frontend/src/view/helpers.ts
@@ -54,7 +54,7 @@ export function getVariables(formValues: FormValues, issues: Issue[]) {
 
       switch (formValues.function[index].value) {
         case 'COUNT':
-          value = issues[index].total;
+          value = issues[index].issues.length;
           break;
       }
 

--- a/src/frontend/src/view/index.test.tsx
+++ b/src/frontend/src/view/index.test.tsx
@@ -60,19 +60,15 @@ describe('with data', () => {
       switch (true) {
         case fetchOptions.body.includes(formValues.jql[1]):
           (response.json as jest.Mock).mockResolvedValue({
-            startAt: 0,
-            maxResults: 0,
-            total: 1,
-            issues: [],
+            isLast: true,
+            issues: [{ id: '123456' }],
           });
           break;
 
         case fetchOptions.body.includes(formValues.jql[0]):
           (response.json as jest.Mock).mockResolvedValue({
-            startAt: 0,
-            maxResults: 0,
-            total: 3,
-            issues: [],
+            isLast: true,
+            issues: [{ id: '123456' }, { id: '234567' }, { id: '345678' }],
           });
           break;
       }


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(frontend): replace deprecated Jira endpoint

Fixes #792

https://developer.atlassian.com/changelog/#CHANGE-2046

## What is the current behavior?

POST `/rest/api/3/search` is deprecated: https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-search/#api-rest-api-3-search-post

## What is the new behavior?

Migrated to POST `/rest/api/3/search/jql`: https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-search/#api-rest-api-3-search-jql-post

One limitation of the new JQL endpoint is that `maxResults` is capped at 5,000

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation